### PR TITLE
Fix broken audio/video functions when sanitizing ID3 data

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2982,7 +2982,7 @@ function wp_add_id3_tag_data( &$metadata, $data ) {
 		if ( ! empty( $data[$version]['comments'] ) ) {
 			foreach ( $data[$version]['comments'] as $key => $list ) {
 				if ( 'length' !== $key && ! empty( $list ) ) {
-					$metadata[$key] = reset( $list );
+					$metadata[$key] = wp_kses_post( reset( $list ) );
 					// Fix bug in byte stream analysis.
 					if ( 'terms_of_use' === $key && 0 === strpos( $metadata[$key], 'yright notice.' ) )
 						$metadata[$key] = 'Cop' . $metadata[$key];
@@ -3072,8 +3072,6 @@ function wp_read_video_metadata( $file ) {
 
 	wp_add_id3_tag_data( $metadata, $data );
 
-	$metadata = wp_kses_post_deep( $metadata );
-
 	return $metadata;
 }
 
@@ -3118,8 +3116,6 @@ function wp_read_audio_metadata( $file ) {
 		$metadata['length_formatted'] = $data['playtime_string'];
 
 	wp_add_id3_tag_data( $metadata, $data );
-
-	$metadata = wp_kses_post_deep( $metadata );
 
 	return $metadata;
 }


### PR DESCRIPTION
This fixes a bug where running `wp_kses_post_deep()` on all the ID3
tag data corrupted blob data.

Fixes #40075, #40085.