### PR TITLE
Media: Improve handling of non-image files in wp_get_image_mime

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2367,7 +2367,8 @@ function wp_get_image_mime( $file ) {
 	 */
 	try {
 		if ( is_callable( 'exif_imagetype' ) ) {
-			$mime = image_type_to_mime_type( exif_imagetype( $file ) );
+			$imagetype = exif_imagetype( $file );
+			$mime = ( $imagetype ) ? image_type_to_mime_type( $imagetype ) : false;
 		} elseif ( function_exists( 'getimagesize' ) ) {
 			$imagesize = getimagesize( $file );
 			$mime = ( isset( $imagesize['mime'] ) ) ? $imagesize['mime'] : false;

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -916,6 +916,18 @@ class Tests_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 40017
+	 * @dataProvider _wp_get_image_mime
+	 */
+	public function test_wp_get_image_mime( $file, $expected ) {
+		if ( ! is_callable( 'exif_imagetype' ) && ! function_exists( 'getimagesize' ) ) {
+			$this->markTestSkipped( 'The exif PHP extension is not loaded.' );
+		}
+
+		$this->assertEquals( $expected, wp_get_image_mime( $file ) );
+	}
+
+	/**
 	 * @ticket 39550
 	 * @dataProvider _wp_check_filetype_and_ext_data
 	 */
@@ -991,6 +1003,38 @@ class Tests_Functions extends WP_UnitTestCase {
 	public function _filter_mime_types_woff( $mimes ) {
 		$mimes['woff'] = 'application/font-woff';
 		return $mimes;
+	}
+
+	public function _wp_get_image_mime() {
+		$data = array(
+			// Standard JPEG.
+			array(
+				DIR_TESTDATA . '/images/test-image.jpg',
+				'image/jpeg',
+			),
+			// Standard GIF.
+			array(
+				DIR_TESTDATA . '/images/test-image.gif',
+				'image/gif',
+			),
+			// Standard PNG.
+			array(
+				DIR_TESTDATA . '/images/test-image.png',
+				'image/png',
+			),
+			// Image with wrong extension.
+			array(
+				DIR_TESTDATA . '/images/test-image-mime-jpg.png',
+				'image/jpeg',
+			),
+			// Not an image.
+			array(
+				DIR_TESTDATA . '/uploads/dashicons.woff',
+				false,
+			),
+		);
+
+		return $data;
 	}
 
 	public function _wp_check_filetype_and_ext_data() {


### PR DESCRIPTION
This prevents non-image fileypes from returning a mime type of
"application/octet-stream" when `exif_imagetype()` returns `false`.

Props blobfolio.
Fixes #40017.