### PR TITLE
Improve handling of unsupported attachments in image_downsize

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -183,7 +183,27 @@ function image_hwstring( $width, $height ) {
  *                     the image is an intermediate size. False on failure.
  */
 function image_downsize( $id, $size = 'medium' ) {
-	$is_image = wp_attachment_is_image( $id );
+	$is_image = false;
+
+	/*
+	 * Check attachment to see if we support returning image attributes for
+	 * this type. This is to avoid the 'image_downsize' filter and making
+	 * unneeded DB queries when the type is unsupported.
+	 */
+	$supported = false;
+	$supported_types = array( 'image', 'pdf' );
+
+	foreach ( $supported_types as $type ) {
+		$supported = wp_attachment_is( $type, $id );
+		if ( $supported ) {
+			$is_image = ( 'image' === $type );
+			break;
+		}
+	}
+
+	if ( ! $supported ) {
+		return false;
+	}
 
 	/**
 	 * Filters whether to preempt the output of image_downsize().


### PR DESCRIPTION
This adds a check for supported filetypes at the beginning of
`image_downsize()`, which currently includes image and pdf file
types. This avoids sending unsupported attachments to the
`image_downsize` fitler, and also avoids unnecessary DB queries
for `_wp_attached_file` or `_wp_attachment_metadata`.