### PR TITLE
Limit image creation during upload to default sizes.

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -456,6 +456,7 @@ add_filter( 'the_content', 'do_shortcode', 11 ); // AFTER wpautop()
 // Media
 add_action( 'wp_playlist_scripts', 'wp_playlist_scripts' );
 add_action( 'customize_controls_enqueue_scripts', 'wp_plupload_default_settings' );
+add_action( 'wp_generate_custom_images', 'wp_generate_attachment_sizes' );
 
 // Nav menu
 add_filter( 'nav_menu_item_id', '_nav_menu_item_id_use_once', 10, 2 );


### PR DESCRIPTION
This PR is the first steps toward fixing [#40439](https://core.trac.wordpress.org/ticket/40439) and improving performance of the image upload process by reducing the number of intermediate sizes created during the upload process.

Currently, WordPress creates intermedia image files during generation of attachment metadata, which can cause the whole upload process to fail if the server can't generate all of the image sizes.

This adds the basic functionality needed to limit the set of sizes generated at one time and adds functionality which generates any missing sizes for an attachment. As a first pass, this limits the generation of intermediate image sizes during uploads to default sizes and the 'post-thumbnail' (if applicable). It also currently uses a scheduled event for generating additional image sizes asynchronously.