### PR TITLE
Media: Prime post caches in 'wp_make_content_images_responsive()'

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1335,12 +1335,10 @@ function wp_make_content_images_responsive( $content ) {
 
 	if ( count( $attachment_ids ) > 1 ) {
 		/*
-		 * Warm object cache for use with 'get_post_meta()'.
-		 *
-		 * To avoid making a database call for each image, a single query
-		 * warms the object cache with the meta information for all images.
-		 */
-		update_meta_cache( 'post', array_keys( $attachment_ids ) );
+		 * Warm the object cache with post and meta information for all found
+		 * images to avoid making individual database calls.
+ 		 */
+		_prime_post_caches( array_keys( $attachment_ids ), false, true );
 	}
 
 	foreach ( $selected_images as $image => $attachment_id ) {


### PR DESCRIPTION
In [38296] we replaced `get_post_meta()` with `wp_get_attachment_metadata()`
so that attachment metadata could be consistently filtered. However, this
resulted in extra post queries that were previously avoided.

This improves post caching before looping through all images to retreieve
attachment metadata, by using `_prime_post_caches()` instead of
`update_meta_cache()`.

Props dlh.
Fixes #40490.