### PR TITLE
PHPUnit: Fix test errors in PHPUnit 6.4.0+

### DIFF
--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -266,10 +266,10 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 
 		// First, test with deprecated wp_load_image function
 		$editor1 = wp_load_image( DIR_TESTDATA );
-		$this->assertNotInternalType( 'resource', $editor1 );
+		$this->assertInternalType( 'string', $editor1 );
 
 		$editor2 = wp_get_image_editor( DIR_TESTDATA );
-		$this->assertNotInternalType( 'resource', $editor2 );
+		$this->assertInstanceOf( 'WP_Error', $editor2 );
 
 		// Then, test with editors.
 		$classes = array('WP_Image_Editor_GD', 'WP_Image_Editor_Imagick');


### PR DESCRIPTION
`Tests_Image_Functions::test_load_directory()` used `assertNotInternalType()`
to ensure `wp_load_image()` and `wp_get_image_editor()` wouldn't load
a link to a resource. Under the hood, PHPUnit uses `get_resource_type()`
in this assertion, which will produce an error that was previously not
surfaced. This updates the two assertions to test for what we expect those
functions to return instead.